### PR TITLE
Fixed node_modules errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,9 +8,12 @@ services:
       WATCHPACK_POLLING: true
     volumes:
       - .:/app
-      - /app/node_modules
+      - node_modules:/app/node_modules
     networks:
       - course-manager-network
+
+volumes:
+  node_modules:
 
 networks:
   course-manager-network:


### PR DESCRIPTION
## Description

<!-- Describe the problem/issue roughly -->
<!-- Or, link the issue -->

When you try to set up the environment on Windows, there's only empty node_modules folder.

## Changes

<!-- Explain the changes in detail -->
- Added `.dockerignore` not to mount node_modules on the host side
- Slightly changed `compose.yaml`

## Screenshots

<!-- Add screenshots if you changed the UI -->

## Concerns

<!-- Leave any comments if you have any concerns -->

Let's see if this solves the problem.

## Checklist

<!-- List up check points that you have checked -->

## Notes

<!-- Any additional notes if you have any -->
